### PR TITLE
 Fixed Xcode 10 migration issue with UIBarButton and custom Style struct

### DIFF
--- a/YandexCheckoutPayments.podspec
+++ b/YandexCheckoutPayments.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name      = 'YandexCheckoutPayments'
-  s.version   = '1.3.3'
+  s.version   = '1.3.4'
   s.homepage  = 'https://github.com/yandex-money/yandex-checkout-payments-swift'
   s.license   = {
     :type => "MIT",

--- a/YandexCheckoutPayments/Atomic Design/Molecules/UIKit+Styles/UIBarButtonItem+Style.swift
+++ b/YandexCheckoutPayments/Atomic Design/Molecules/UIKit+Styles/UIBarButtonItem+Style.swift
@@ -34,7 +34,7 @@ extension UIBarButtonItem {
         /// Close bar button item.
         ///
         /// Image `barButtonItem.close`.
-        static let close = Style(name: "close") { (item: UIBarButtonItem) in
+        static let close = YandexCheckoutPayments.Style(name: "close") { (item: UIBarButtonItem) in
             item.style = .plain
             item.image = .templatedClose
         }
@@ -42,7 +42,7 @@ extension UIBarButtonItem {
         /// Back bar button item.
         ///
         /// Image `barButtonItem.back`.
-        static let back = Style(name: "back") { (item: UIBarButtonItem) in
+        static let back = YandexCheckoutPayments.Style(name: "back") { (item: UIBarButtonItem) in
             item.style = .plain
             item.image = .back
         }
@@ -50,7 +50,7 @@ extension UIBarButtonItem {
         /// Close bar button item with ability to set tint color.
         ///
         /// Image `button.templatedClose`.
-        static let templatedClose = Style(name: "templatedClose") { (item: UIBarButtonItem) in
+        static let templatedClose = YandexCheckoutPayments.Style(name: "templatedClose") { (item: UIBarButtonItem) in
             item.tintColor = nil
             item.style = .plain
             item.image = .templatedClose


### PR DESCRIPTION
Xcode 10 is released with new Swift where UIBarButton has its own Style enum.

[Updated documentation](https://developer.apple.com/documentation/uikit/uibarbuttonitem/style)