### PR TITLE
Fix deprecated method openURL for ios 10.0

### DIFF
--- a/YandexCheckoutPaymentsExample/Source/UserStories/Root/RootViewController.swift
+++ b/YandexCheckoutPaymentsExample/Source/UserStories/Root/RootViewController.swift
@@ -577,7 +577,7 @@ extension RootViewController: SuccessViewControllerDelegate {
                 }
                 strongSelf.present(viewController, animated: true)
             } else {
-                UIApplication.shared.openURL(url)
+                UIApplication.shared.open(url, options: [:], completionHandler: nil)
             }
         }
     }


### PR DESCRIPTION
Добрый день, заметил, что не компилится проект с версией 3.7.1 и выдает такую ошибку в YandexCheckoutPaymentsExample, если выставить ios deployment target 10.0.

<img width="628" alt="image" src="https://user-images.githubusercontent.com/18047528/94019488-88421d00-fdba-11ea-8371-06ffb1cee2d4.png">
